### PR TITLE
Ports ColorWall to python3.6 using 2to3.

### DIFF
--- a/effects.py
+++ b/effects.py
@@ -424,7 +424,7 @@ class LetterTest(Effect):
 
         # Display upper and lower case letters. The break between 90 and 97 is
         # for non-letter keyboard characters.
-        for ord in range(65, 91) + range(97, 123):
+        for ord in list(range(65, 91)) + list(range(97, 123)):
             self.wall.clear()
 
             # Set every pixel to the background color, since ascii8x8 will only

--- a/run.py
+++ b/run.py
@@ -25,5 +25,5 @@ if __name__ == "__main__":
 
     for effect in effects_to_run:
         new_effect = effect(wall)
-        print new_effect.__class__.__name__
+        print(new_effect.__class__.__name__)
         new_effect.run()

--- a/wall.py
+++ b/wall.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from Tkinter import ALL, Canvas, Frame, SUNKEN, Tk
+from tkinter import ALL, Canvas, Frame, SUNKEN, Tk
 import colorsys
 
 """
@@ -62,7 +62,7 @@ class Wall(object):
         self.canvas.delete(ALL)
         for x in range(len(self.pixels)):
             x_0 = (x % self.width) * self.PIXEL_WIDTH
-            y_0 = (x / self.width) * self.PIXEL_WIDTH
+            y_0 = (x // self.width) * self.PIXEL_WIDTH
             x_1 = x_0 + self.PIXEL_WIDTH
             y_1 = y_0 + self.PIXEL_WIDTH
             hue = "#%02x%02x%02x" % self._get_rgb(self.pixels[x])


### PR DESCRIPTION
This works for me now with Python 3.6.4 on Ubuntu 17.10.

In `_get_rgb` L85-L87 there is another Python2.7 style `/`, I think the `int(float(value))` construction there could be simplified further.